### PR TITLE
add eslint-plugin-jsx-a11y so when test is run, doesn't error on lint checking

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.9.2",
     "eslint-plugin-jasmine": "^1.8.1",
+    "eslint-plugin-jsx-a11y": "^1.5.3",
     "eslint-plugin-react": "^5.2.2",
     "fetch-mock": "^4.5.4",
     "html-webpack-plugin": "^2.21.0",


### PR DESCRIPTION
Got this error when running `npm run test`

```
Oops! Something went wrong! :(

ESLint couldn't find the plugin "eslint-plugin-jsx-a11y". This can happen for a couple different reasons:

1. If ESLint is installed globally, then make sure eslint-plugin-jsx-a11y is also installed globally. A globally-installed ESLint cannot find a locally-installed plugin.

2. If ESLint is installed locally, then it's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm i eslint-plugin-jsx-a11y@latest --save-dev
```

So added that to `package.json` so it is not expected globally.  Though if this was my own fault for other bad setup, then drop this
